### PR TITLE
Build Automation using Node.js scripts - “test:dev”, “test:api" RuiRi…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ task runUnitTests(type: NodeTask) {
 task generateUnitTestsCoverageReport(type: NodeTask) {
     dependsOn runUnitTests
     script = file('node_modules/jest/bin/jest.js')
-    args = ["--coverage", "--coverageReporters=text,html,json"]
+    args = ['--coverage', '--testPathIgnorePatterns=api', '--coverageReporters=text,html,json']
 }
 
 task runApiTests(type: NodeTask) {


### PR DESCRIPTION
…oPina/ddd-forum-odsoft-NCF_5#5 Quick fix for the build.gradle. The generateUnitTestsCoverageReport task was also running the api tests, added a argument to prevent that.